### PR TITLE
ServiceBusStatus: FlagsAttribute misleading

### DIFF
--- a/src/NHN.DtoContracts/NHN.DtoContracts/ServiceBusConnector/Enum/ServiceBusStatus.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/ServiceBusConnector/Enum/ServiceBusStatus.cs
@@ -6,8 +6,13 @@ namespace NHN.DtoContracts.ServiceBusConnector.Enum
     /// <summary>
     /// Status for melding i service bus
     /// </summary>
+    /// 
+    /// <remarks>
+    /// Denne er definert med [Flags], men dette er misvisende.
+    /// Enumen er ikke ment å brukes med `HasFlag(...)`
+    /// </remarks>
     [DataContract(Namespace = "http://register.nhn.no/ServiceBusConnector")]
-    [Flags]
+    [Flags] // Misvisende, men kan ikke fjernes
     [Serializable]
     public enum ServiceBusStatus
     {
@@ -16,11 +21,13 @@ namespace NHN.DtoContracts.ServiceBusConnector.Enum
         /// </summary>
         [EnumMember]
         InQueue,
+
         /// <summary>
         /// Meldingen er ikke på kø
         /// </summary>
         [EnumMember]
         NotInQueue,
+
         /// <summary>
         /// Melding i deadletter-kø
         /// </summary>


### PR DESCRIPTION
But we can't remove it, as it would change an exposed contract.
Remark it in the documentation.