### PR TITLE
Convert æøå to utf8 for .cs and .cshtml

### DIFF
--- a/src/NHN.DtoContracts/NHN.DtoContracts/Common/en/Code.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Common/en/Code.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.Serialization;
 
 namespace NHN.DtoContracts.Common.en

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Common/en/ElectronicAddress.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Common/en/ElectronicAddress.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.Serialization;
 
 namespace NHN.DtoContracts.Common.en

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Common/en/OpeningHours.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Common/en/OpeningHours.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Common/en/Period.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Common/en/Period.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.Serialization;
 
 namespace NHN.DtoContracts.Common.en

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Common/en/PhysicalAddress.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Common/en/PhysicalAddress.cs
@@ -4,7 +4,7 @@ using System.Runtime.Serialization;
 namespace NHN.DtoContracts.Common.en
 {
     /// <summary>
-    /// Fysisk adresse, f.eks. besøks-, post- eller fakturaadresse.
+    /// Fysisk adresse, f.eks. besÃ¸ks-, post- eller fakturaadresse.
     /// </summary>
     [DataContract(Namespace = Namespaces.CommonOldV1)]
     [Serializable]
@@ -77,7 +77,7 @@ namespace NHN.DtoContracts.Common.en
         public string City { get; set; }
 
         /// <summary>
-        /// Fritekst felt for ekstra beskrivelse. For eksempel ”Samme inngang som ICA, ta innerste dør til venstre”
+        /// Fritekst felt for ekstra beskrivelse. For eksempel â€Samme inngang som ICA, ta innerste dÃ¸r til venstreâ€
         /// </summary>
         [DataMember]
         public string Description { get; set; }
@@ -105,7 +105,7 @@ namespace NHN.DtoContracts.Common.en
         public Code Municipality { get; set; }
 
         /// <summary>
-        /// Opprette Code for en fysisk adresse basert på adresssens kodeveri..
+        /// Opprette Code for en fysisk adresse basert pÃ¥ adresssens kodeveri..
         /// </summary>
         /// <param name="codeValue"></param>
         /// <returns></returns>

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Common/en/Status.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Common/en/Status.cs
@@ -4,7 +4,7 @@ using System.Runtime.Serialization;
 namespace NHN.DtoContracts.Common.en
 {
     /// <summary>
-    /// Status basert på en periode og kodeverk
+    /// Status basert pÃ¥ en periode og kodeverk
     /// </summary>
     [DataContract(Namespace = Namespaces.CommonOldV1)]
     [Serializable]

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Common/en/TimePeriod.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Common/en/TimePeriod.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.Serialization;
 
 namespace NHN.DtoContracts.Common.en

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/ContractsQueryParameters.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/ContractsQueryParameters.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 using NHN.DtoContracts.Common.en;
 using System.Linq;

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/GPContract.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/GPContract.cs
@@ -1,4 +1,4 @@
-﻿using NHN.DtoContracts.Common.en;
+using NHN.DtoContracts.Common.en;
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/GPContractQueryParameters.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/GPContractQueryParameters.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 using NHN.DtoContracts.Common.en;
 
 namespace NHN.DtoContracts.Flr.Data

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/GPDetails.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/GPDetails.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 using NHN.DtoContracts.Common.en;
 

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/GPOffice.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/GPOffice.cs
@@ -1,4 +1,4 @@
-﻿using NHN.DtoContracts.Common.en;
+using NHN.DtoContracts.Common.en;
 using System;
 using System.Runtime.Serialization;
 using NHN.DtoContracts.Htk;

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/GPOnContractAssociation.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/GPOnContractAssociation.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using NHN.DtoContracts.Common.en;

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/GPSearchParameters.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/GPSearchParameters.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 using NHN.DtoContracts.Common.en;
 
 namespace NHN.DtoContracts.Flr.Data

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/GetNavPatientListsParameters.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/GetNavPatientListsParameters.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/NavEncryptedPatientListParameters.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/NavEncryptedPatientListParameters.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.Serialization;
 
 namespace NHN.DtoContracts.Flr.Data

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/NinWithTimestamp.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/NinWithTimestamp.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.Serialization;
 
 namespace NHN.DtoContracts.Flr.Data

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/OutOfOfficeLocation.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/OutOfOfficeLocation.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using NHN.DtoContracts.Common.en;

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/PatientToGPContractAssociation.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/PatientToGPContractAssociation.cs
@@ -13,29 +13,29 @@ namespace NHN.DtoContracts.Flr.Data
     public class PatientToGPContractAssociation
     {
         /// <summary>
-        /// Id til denne assosiasjonen. TilhørighetsId
+        /// Id til denne assosiasjonen. TilhÃ¸righetsId
         /// </summary>
         [DataMember]
         public long Id { get; set; }
 
         /// <summary>
-        /// ID til GPContract. Må være satt ved skriving, vil være satt ved lesing og vil være identisk med GPContract.Id.
+        /// ID til GPContract. MÃ¥ vÃ¦re satt ved skriving, vil vÃ¦re satt ved lesing og vil vÃ¦re identisk med GPContract.Id.
         /// </summary>
         [DataMember]
         public long GPContractId { get; set; }
 
         /// <summary>
-        /// Kontakten denne assosiasjonen peker til. Satt ved lesing, skal være null ved skriving.
+        /// Kontakten denne assosiasjonen peker til. Satt ved lesing, skal vÃ¦re null ved skriving.
         /// </summary>
         [DataMember]
         public GPContract GPContract { get; set; }
 
         /// <summary>
         /// HerId for adressering til fastlegetjenesten.
-        /// Dette er HerId til fastlegen som er aktiv på listen på dagens dato, dersom en slik finnes.
-        /// Hvis ikke returneres det HerId for fastlegelistens tjenestebaserte kommunikasjonspart av typen "Fastlege, liste uten fast lege", dersom en slik finnes definert på virksomhetsnivå.
+        /// Dette er HerId til fastlegen som er aktiv pÃ¥ listen pÃ¥ dagens dato, dersom en slik finnes.
+        /// Hvis ikke returneres det HerId for fastlegelistens tjenestebaserte kommunikasjonspart av typen "Fastlege, liste uten fast lege", dersom en slik finnes definert pÃ¥ virksomhetsnivÃ¥.
         /// Returnerer NULL dersom passende HerId ikke finnes. 
-        /// Feltet vil kun være satt for leseoperasjoner som spør på dagens dato, ikke på historiske data. Brukes ikke på skriveoperasjoner.
+        /// Feltet vil kun vÃ¦re satt for leseoperasjoner som spÃ¸r pÃ¥ dagens dato, ikke pÃ¥ historiske data. Brukes ikke pÃ¥ skriveoperasjoner.
         /// </summary>
         [DataMember]
         public int? GPHerId { get; set; }
@@ -48,34 +48,34 @@ namespace NHN.DtoContracts.Flr.Data
 
         /// <summary>
         /// Hvilken periode denne assosiasjonen er gyldig for.
-        /// For Move metoden er dette perioden på den nye assosiasjonen. Den gamle assosiasjonen får TilDato satt til ny FraDato.
+        /// For Move metoden er dette perioden pÃ¥ den nye assosiasjonen. Den gamle assosiasjonen fÃ¥r TilDato satt til ny FraDato.
         /// </summary>
         [DataMember]
         public Period Period { get; set; } //FraDato ?TilDato;
 
         /// <summary>
-        /// Kode på hvorfor perioden er endret (avsluttet). Er NULL normalt sett med mindre personen har forlatt ordningen.
+        /// Kode pÃ¥ hvorfor perioden er endret (avsluttet). Er NULL normalt sett med mindre personen har forlatt ordningen.
         /// Kodeverk: <see href="/CodeAdmin/EditCodesInGroup/flrv2_endreason">flrv2_endreason</see> (OID 7753).
         /// </summary>
         [DataMember]
         public Code EndCode { get; set; }
 
         /// <summary>
-        /// Kode på hvorfor perioden er startet.
+        /// Kode pÃ¥ hvorfor perioden er startet.
         /// Kodeverk: <see href="/CodeAdmin/EditCodesInGroup/flrv2_beginreason">flrv2_beginreason</see> (OID 7754).
         /// </summary>
         [DataMember]
         public Code BeginCode { get; set; }
 
         /// <summary>
-        /// Detaljer om pasienten. Dette vil være satt på leseoperasjoner når det er relevant, men må være NULL på skriveoperasjoner.
+        /// Detaljer om pasienten. Dette vil vÃ¦re satt pÃ¥ leseoperasjoner nÃ¥r det er relevant, men mÃ¥ vÃ¦re NULL pÃ¥ skriveoperasjoner.
         /// </summary>
         [DataMember]
         public Person Patient { get; set; }
 
         /// <summary>
-        /// Legeperioder som overlapper med denne pasientperioden på listen. Dette vil være satt på leseoperasjoner når det er relevant, 
-        /// men må være NULL på skriveoperasjoner.
+        /// Legeperioder som overlapper med denne pasientperioden pÃ¥ listen. Dette vil vÃ¦re satt pÃ¥ leseoperasjoner nÃ¥r det er relevant, 
+        /// men mÃ¥ vÃ¦re NULL pÃ¥ skriveoperasjoner.
         /// </summary>
         [DataMember]
         public IList<GPOnContractAssociation> DoctorCycles { get; set; }

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/Person.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/Person.cs
@@ -13,7 +13,7 @@ namespace NHN.DtoContracts.Flr.Data
     public class Person
     {
         /// <summary>
-        /// Fødselsnummer, D-nummer eller H-nummer.
+        /// FÃ¸dselsnummer, D-nummer eller H-nummer.
         /// </summary>
         [DataMember]
         public string NIN { get; set; }
@@ -37,19 +37,19 @@ namespace NHN.DtoContracts.Flr.Data
         public string LastName { get; set; }
 
         /// <summary>
-        /// Fødselsdato.
+        /// FÃ¸dselsdato.
         /// </summary>
         [DataMember]
         public DateTime? DateOfBirth { get; set; }
 
         /// <summary>
-        /// Tidspunkt personen døde på.
+        /// Tidspunkt personen dÃ¸de pÃ¥.
         /// </summary>
         [DataMember]
         public DateTime? DateOfDeath { get; set; }
 
         /// <summary>
-        /// Kjønn.
+        /// KjÃ¸nn.
         /// Kodeverk: <see href="/CodeAdmin/EditCodesInGroup/kjonn">kjonn</see> (OID 3101).
         /// </summary>
         [DataMember]
@@ -63,7 +63,7 @@ namespace NHN.DtoContracts.Flr.Data
         public IList<Status> Status { get; set; }
 
         /// <summary>
-        /// Adresser tilhørende personen.
+        /// Adresser tilhÃ¸rende personen.
         /// </summary>
         [DataMember]
         public IList<PhysicalAddress> PhysicalAddresses { get; set; }

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/PrimaryHealthCareContract.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/PrimaryHealthCareContract.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.Serialization;
 using NHN.DtoContracts.Common.en;
 

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/PrimaryHealthCareContractEdit.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/PrimaryHealthCareContractEdit.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.Serialization;
 using NHN.DtoContracts.Common.en;
 

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/PrimaryHealthCareTeam.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/PrimaryHealthCareTeam.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/PrimaryHealthCareTeamEdit.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Data/PrimaryHealthCareTeamEdit.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Enum/FlrEvents.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Enum/FlrEvents.cs
@@ -10,14 +10,14 @@ namespace NHN.DtoContracts.Flr.Enum
     public enum FlrEvents
     {
         /// <summary>
-        /// Publiseres når en ny fastlegeavtale blir opprettet.
+        /// Publiseres nÃ¥r en ny fastlegeavtale blir opprettet.
         /// 
         /// Se <see cref="IFlrWriteOperations.CreateGPContract" />.
         /// </summary>
         ContractCreated,
 
         /// <summary>
-        /// Publiseres når en fastlegeavtale blir oppdatert med ny informasjon.
+        /// Publiseres nÃ¥r en fastlegeavtale blir oppdatert med ny informasjon.
         /// 
         /// Se <see cref="IFlrWriteOperations.UpdateGPContract" />,
         /// <see cref="IFlrWriteOperations.UpdateGPContractMaxPatients" />,
@@ -29,35 +29,35 @@ namespace NHN.DtoContracts.Flr.Enum
         ContractUpdated,
 
         /// <summary>
-        /// Publiseres når en fastlegeavtale blir avsluttet.
+        /// Publiseres nÃ¥r en fastlegeavtale blir avsluttet.
         /// 
         /// Se <see cref="IFlrWriteOperations.CancelGPContractAndMovePatients" />.
         /// </summary>
         ContractCanceled,
 
         /// <summary>
-        /// Publiseres når en ny legeperiode blir koblet mot en fastlegeavtale.
+        /// Publiseres nÃ¥r en ny legeperiode blir koblet mot en fastlegeavtale.
         /// 
         /// Se <see cref="IFlrWriteOperations.CreateGPOnContractAssociation" />.
         /// </summary>
         GPOnContractCreated,
 
         /// <summary>
-        /// Publiseres når en legeperiode blir oppdatert med ny informasjon.
+        /// Publiseres nÃ¥r en legeperiode blir oppdatert med ny informasjon.
         /// 
         /// Se <see cref="IFlrWriteOperations.UpdateGPOnContractAssociation" />.
         /// </summary>
         GPOnContractUpdated,
 
         /// <summary>
-        /// Publiseres når en legeperiode blir slettet.
+        /// Publiseres nÃ¥r en legeperiode blir slettet.
         /// 
         /// Se <see cref="IFlrWriteOperations.DeleteGPOnContractAssociation" />.
         /// </summary>
         GPOnContractDeleted,
 
         /// <summary>
-        /// Publiseres når en pasient blir oppført på pasientlisten tilhørende en fastlegeavtale.
+        /// Publiseres nÃ¥r en pasient blir oppfÃ¸rt pÃ¥ pasientlisten tilhÃ¸rende en fastlegeavtale.
         /// 
         /// Se <see cref="IFlrWriteOperations.CreatePatientToGPContractAssociation" />,
         /// <see cref="IFlrWriteOperations.MovePatients" />,
@@ -66,14 +66,14 @@ namespace NHN.DtoContracts.Flr.Enum
         PatientOnContractCreated,
 
         /// <summary>
-        /// Publiseres når en pasient blir oppdatert med ny informasjon.
+        /// Publiseres nÃ¥r en pasient blir oppdatert med ny informasjon.
         /// 
         /// Se <see cref="IFlrWriteOperations.UpdatePatientNin"/>
         /// </summary>
         PatientOnContractUpdated,
 
         /// <summary>
-        /// Publiseres når en pasient blir avsluttet på fastlegeavtalen.
+        /// Publiseres nÃ¥r en pasient blir avsluttet pÃ¥ fastlegeavtalen.
         /// 
         /// Se <see cref="IFlrWriteOperations.CancelPatientOnGPContract" />, 
         /// <see cref="IFlrWriteOperations.CancelPatientsOnGPContract" />
@@ -81,28 +81,28 @@ namespace NHN.DtoContracts.Flr.Enum
         PatientOnContractCanceled,
 
         /// <summary>
-        /// Publiseres når en pasients fødselsnummer blir endret.
+        /// Publiseres nÃ¥r en pasients fÃ¸dselsnummer blir endret.
         /// 
         /// Se <see cref="IFlrWriteOperations.UpdatePatientNin" />.
         /// </summary>
         PatientNinChanged,
 
         /// <summary>
-        /// Publiseres når et nytt utekontor blir opprettet på en fastlegeavtale.
+        /// Publiseres nÃ¥r et nytt utekontor blir opprettet pÃ¥ en fastlegeavtale.
         /// 
         /// Se <see cref="IFlrWriteOperations.CreateOutOfOfficeLocation" />.
         /// </summary>
         OutOfOfficeLocationCreated,
 
         /// <summary>
-        /// Publiseres når et utekontor blir oppdatert med ny informasjon.
+        /// Publiseres nÃ¥r et utekontor blir oppdatert med ny informasjon.
         /// 
         /// Se <see cref="IFlrWriteOperations.UpdateOutOfOfficeLocation" />.
         /// </summary>
         OutOfOfficeLocationUpdated,
 
         /// <summary>
-        /// Publiseres når et utekontor blir slettet.
+        /// Publiseres nÃ¥r et utekontor blir slettet.
         /// 
         /// Se <see cref="IFlrWriteOperations.RemoveOutOfOfficeLocation" />.
         /// </summary>

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Service/IFlrExportOperations.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Service/IFlrExportOperations.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.ServiceModel;
 using NHN.DtoContracts.Common.en;

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Service/IFlrReadOperations.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Service/IFlrReadOperations.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.ServiceModel;
 using NHN.DtoContracts.Common.en;
 using System;

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Service/IFlrWriteOperations.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Flr/Service/IFlrWriteOperations.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NHN.DtoContracts.Common.en;
 using System.Collections.Generic;
 using System.ServiceModel;

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Htk/Business.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Htk/Business.cs
@@ -13,19 +13,19 @@ namespace NHN.DtoContracts.Htk
     public class Business
     {
         /// <summary>
-        /// Organisajonsnummer på enheten
+        /// Organisajonsnummer pÃ¥ enheten
         /// </summary>
         [DataMember]
         public int OrganizationNumber { get; set; }
 
         /// <summary>
-        /// Det registrerte juridiske navnet på enheten.
+        /// Det registrerte juridiske navnet pÃ¥ enheten.
         /// </summary>
         [DataMember]
         public string Name { get; set; }
 
         /// <summary>
-        /// Visningsnavn på enheten.
+        /// Visningsnavn pÃ¥ enheten.
         /// </summary>
         [DataMember]
         public string DisplayName { get; set; }
@@ -37,13 +37,13 @@ namespace NHN.DtoContracts.Htk
         public Period Valid { get; set; }
 
         /// <summary>
-        /// Organisajonsnummer på eventuell overliggende enhet.
+        /// Organisajonsnummer pÃ¥ eventuell overliggende enhet.
         /// </summary>
         [DataMember]
         public int? ParentOrganizationNumber { get; set; }
 
         /// <summary>
-        /// Organisajonsnavn på eventuell overliggende enhet.
+        /// Organisajonsnavn pÃ¥ eventuell overliggende enhet.
         /// </summary>
         [DataMember]
         public string ParentOrganizationName { get; set; }
@@ -68,7 +68,7 @@ namespace NHN.DtoContracts.Htk
         public IList<Code> Properties { get; set; }
 
         /// <summary>
-        /// Fysiske addresser (f.eks. besøks-, post- og fakturaadresse).
+        /// Fysiske addresser (f.eks. besÃ¸ks-, post- og fakturaadresse).
         /// Gyldige verdier: OID 3401
         /// </summary>
         [DataMember]
@@ -95,7 +95,7 @@ namespace NHN.DtoContracts.Htk
         public Code Municipality { get; set; }
 
         /// <summary>
-        /// Næringskoder.
+        /// NÃ¦ringskoder.
         /// Kodeverk: <see href="/CodeAdmin/EditCodesInGroup/naringskode">naringskode</see> (SN2007).
         /// </summary>
         [DataMember]
@@ -110,25 +110,25 @@ namespace NHN.DtoContracts.Htk
 
         /// <summary>
         /// Hvorvidt det er en statlig/kommunal eller privateid bedrift. Utledet av SectorCode.
-        /// Er null når det er ukjent.
+        /// Er null nÃ¥r det er ukjent.
         /// </summary>
         [DataMember]
         public bool? IsGovernmentCompany { get; set; }
 
         /// <summary>
-        /// Åpningstider for bedriften. Hvis feltet er null så arves data fra overliggende enhet.
+        /// Ã…pningstider for bedriften. Hvis feltet er null sÃ¥ arves data fra overliggende enhet.
         /// </summary>
         [DataMember]
         public OpeningHours OpeningHours { get; set; }
 
         /// <summary>
-        /// Koordinator for besøksadresse. Angitt i breddegrad/lengdegrad.
+        /// Koordinator for besÃ¸ksadresse. Angitt i breddegrad/lengdegrad.
         /// </summary>
         [DataMember]
         public LatitudeLongitude? GeographicalCoordinates { get; set; }
 
         /// <summary>
-        /// Når bedriften er sist oppdatert
+        /// NÃ¥r bedriften er sist oppdatert
         /// </summary>
         [DataMember]
         public DateTime UpdatedOn { get; set; }

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Logging/Data/RequestTrackedLog.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Logging/Data/RequestTrackedLog.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Logging/Data/RequestTrackedLogParameter.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Logging/Data/RequestTrackedLogParameter.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 namespace NHN.DtoContracts.Logging.Data
 {

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Logging/Data/RequestTrackedLogQueryParameters.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Logging/Data/RequestTrackedLogQueryParameters.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.Serialization;
 using NHN.DtoContracts.Common.en;
 

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Logging/Service/ILogFetchingService.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Logging/Service/ILogFetchingService.cs
@@ -1,4 +1,4 @@
-﻿using System.ServiceModel;
+using System.ServiceModel;
 using NHN.DtoContracts.Common.en;
 using NHN.DtoContracts.Logging.Data;
 

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Ofr/Data/AddPersonData.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Ofr/Data/AddPersonData.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Ofr/Data/HealthRegister.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Ofr/Data/HealthRegister.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NHN.DtoContracts.Common.en;
 using System.Collections.Generic;
 using System.Runtime.Serialization;

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Ofr/Data/HealthRegisterQuery.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Ofr/Data/HealthRegisterQuery.cs
@@ -1,4 +1,4 @@
-﻿using NHN.DtoContracts.Common.en;
+using NHN.DtoContracts.Common.en;
 using System;
 using System.Runtime.Serialization;
 

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Ofr/Data/PersonAssociations.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Ofr/Data/PersonAssociations.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace NHN.DtoContracts.Ofr.Data

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Ofr/Data/PersonOnHealthRegister.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Ofr/Data/PersonOnHealthRegister.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NHN.DtoContracts.Common.en;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Ofr/Service/IOfrService.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Ofr/Service/IOfrService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ServiceModel;
 using NHN.DtoContracts.Common.en;

--- a/src/NHN.DtoContracts/NHN.DtoContracts/ServiceBus/Data/SubscriptionInfo.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/ServiceBus/Data/SubscriptionInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 namespace NHN.DtoContracts.ServiceBus.Data
 {

--- a/src/NHN.DtoContracts/NHN.DtoContracts/ServiceBus/Service/IServiceBusManager.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/ServiceBus/Service/IServiceBusManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.ServiceModel;
 using NHN.DtoContracts.Common.en;
 using NHN.DtoContracts.ServiceBus.Data;

--- a/src/NHN.DtoContracts/NHN.DtoContracts/ServiceBusConnector/Enum/ServiceBusStatus.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/ServiceBusConnector/Enum/ServiceBusStatus.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.Serialization;
 
 namespace NHN.DtoContracts.ServiceBusConnector.Enum

--- a/src/NHN.DtoContracts/NHN.DtoContracts/ServiceBusConnector/Service/IServicebusService.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/ServiceBusConnector/Service/IServicebusService.cs
@@ -1,4 +1,4 @@
-﻿using System.ServiceModel;
+using System.ServiceModel;
 using System.Threading.Tasks;
 using NHN.DtoContracts;
 using NHN.DtoContracts.Common.en;

--- a/src/NHN.DtoContracts/NHN.WcfClientFactory/Hostnames.cs
+++ b/src/NHN.DtoContracts/NHN.WcfClientFactory/Hostnames.cs
@@ -1,4 +1,4 @@
-﻿namespace NHN.WcfClientFactory
+namespace NHN.WcfClientFactory
 {
     /// <summary>
     /// Inneholder konstanter for hostname til ulike miljø for Registerplatformen.

--- a/src/NHN.DtoContracts/NHN.WcfClientFactory/ServiceContractConfig.cs
+++ b/src/NHN.DtoContracts/NHN.WcfClientFactory/ServiceContractConfig.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ServiceModel;
 
 namespace NHN.WcfClientFactory

--- a/src/NHN.DtoContracts/NHN.WcfClientFactory/WcfClientFactory.cs
+++ b/src/NHN.DtoContracts/NHN.WcfClientFactory/WcfClientFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ServiceModel;
 using System.ServiceModel.Channels;


### PR DESCRIPTION
Replaces æøå with UTF8 characters, to avoid encoding issues.

This change basically searches all .cs and .cshtml files and if they contain any of the ISO-8951 encoded æøå’s (0xe5, 0xe6 or 0xf8) it converts the entire file to UTF8 using .NET’s built-in conversion (UTF8 without BOM).