### PR TITLE
support .NET Standard 2.0

### DIFF
--- a/src/NHN.DtoContracts/NHN.DtoContracts/Common/en/GenericFault.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Common/en/GenericFault.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 using System.ServiceModel;
 
 namespace NHN.DtoContracts.Common.en
@@ -36,7 +36,11 @@ namespace NHN.DtoContracts.Common.en
         public static FaultException<GenericFault> Create(string errorCode, string message)
         {
             var fault = new GenericFault(errorCode, message);
+#if NETSTANDARD2_0
+            return new FaultException<GenericFault>(fault, new FaultReason(fault.Message), new FaultCode(errorCode), fault.Message);
+#else
             return new FaultException<GenericFault>(fault, fault.Message);
+#endif
         }
     }
 }

--- a/src/NHN.DtoContracts/NHN.DtoContracts/NHN.DtoContracts.CPS.netstandard2.0.csproj
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/NHN.DtoContracts.CPS.netstandard2.0.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>NHN.DtoContracts</RootNamespace>
+    <AssemblyName>NHN.DtoContracts</AssemblyName>
+
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.6.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Diagrams\Ofr.cd" />
+    <None Include="Diagrams\FLR.cd" />
+  </ItemGroup>
+
+</Project>

--- a/src/NHN.DtoContracts/NHN.WcfClientFactory/NHN.WcfClientFactory.netstandard2.0.csproj
+++ b/src/NHN.DtoContracts/NHN.WcfClientFactory/NHN.WcfClientFactory.netstandard2.0.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>NHN.WcfClientFactory</RootNamespace>
+    <AssemblyName>NHN.WcfClientFactory</AssemblyName>
+
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.6.0" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NHN.DtoContracts\NHN.DtoContracts.CPS.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Added separate csproj files for .NET Standard 2.0. Had to add a conditional on the code due to a difference between `System.ServiceModel` NuGet and the .NET Framework implementation.