### PR TITLE
Cleaned up System.ServiceModel references. Contracts only use System.…

### DIFF
--- a/src/NHN.DtoContracts/NHN.DtoContracts/NHN.DtoContracts.csproj
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/NHN.DtoContracts.csproj
@@ -16,10 +16,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="System.ServiceModel.Duplex" Version="4.8.1" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.8.1" />
-    <PackageReference Include="System.ServiceModel.Federation" Version="4.8.1" />
     <PackageReference Include="Microsoft.Build.Framework" Version="16.10.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.8.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Flr\FLRXmlNamespace.cs" />


### PR DESCRIPTION
Cleaned up System.ServiceModel references. Contracts only use System.ServiceModel.Primitives which only was provided through a dependency on the library by the other unused System.ServiceModel.* NuGet-packages