### PR TITLE
revert Commit 6a0e3d1 - fix spelling of type adressekomponeneter

### DIFF
--- a/src/NHN.DtoContracts/NHN.DtoContracts/Common/en/ElectronicAddress.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Common/en/ElectronicAddress.cs
@@ -45,7 +45,7 @@ namespace NHN.DtoContracts.Common.en
 
         /// <summary>
         /// Type elektronisk adresse.
-        /// Kodeverk: <see href="/CodeAdmin/EditCodesInGroup/type_adressekomponenter">type_adressekomponenter</see> (OID 9044).
+        /// Kodeverk: <see href="/CodeAdmin/EditCodesInGroup/type_adressekomponeneter">type_adressekomponeneter</see> (OID 9044).
         /// Gyldige verdier er verdiene som starter med E_.
         /// </summary>
         [DataMember]
@@ -54,7 +54,7 @@ namespace NHN.DtoContracts.Common.en
             get
             {
                 if (_type == null && !string.IsNullOrEmpty(_typeCodeValue))
-                    _type = new Code("type_adressekomponenter", 9044, _typeCodeValue);
+                    _type = new Code("type_adressekomponeneter", 9044, _typeCodeValue);
 
                 return _type;
             }
@@ -91,7 +91,7 @@ namespace NHN.DtoContracts.Common.en
         /// <returns>Kodeobjekt. Description vil ikke være satt.</returns>
         public static Code CreateAddressTypeCode(string codeValue)
         {
-            return new Code("type_adressekomponenter", 9044, codeValue);
+            return new Code("type_adressekomponeneter", 9044, codeValue);
         }
     }
 }

--- a/src/NHN.DtoContracts/NHN.DtoContracts/Ofr/Data/HealthRegister.cs
+++ b/src/NHN.DtoContracts/NHN.DtoContracts/Ofr/Data/HealthRegister.cs
@@ -104,7 +104,7 @@ namespace NHN.DtoContracts.Ofr.Data
         /// <summary>
         /// Elektroniske adresser til eieren av registeret. I hovedsak er dette snakk om en Hjemmeside representert av kodeverdien E_URL,
         /// og en Adresselenke for innsynsrett representert av kodeverdien E_PTL
-        /// Kodeverk: <see href="/CodeAdmin/EditCodesInGroup/type_adressekomponenter">type_adressekomponenter</see> (OID 9044).
+        /// Kodeverk: <see href="/CodeAdmin/EditCodesInGroup/type_adressekomponeneter">type_adressekomponeneter</see> (OID 9044).
         /// </summary>
         [DataMember, Required]
         public IList<ElectronicAddress> ElectronicAddresses { get; set; }


### PR DESCRIPTION
revert Commit 6a0e3d1 - fix spelling of type adressekomponeneter (https://github.com/NorskHelsenett/NHNDtoContracts/commit/6a0e3d1c454d48b19d1ab760179fc678ddd35967)

This change will not be done after all. The spelling mistake will live forever. 